### PR TITLE
fix(auth): properly translate error messages using locale from route

### DIFF
--- a/app/[locale]/(auth)/sign-in/page.tsx
+++ b/app/[locale]/(auth)/sign-in/page.tsx
@@ -3,6 +3,7 @@ import ROUTES_API from "~/constants/urls/api.urls";
 import AuthenticationCard from "~/app/components/cards/authentication.card";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
+import { getLocale } from "next-intl/server";
 import axios from "axios";
 
 export default function SignInPage() {
@@ -11,8 +12,9 @@ export default function SignInPage() {
 
     const email = formData.get("email") as string;
     const password = formData.get("password") as string;
+    const locale = await getLocale();
     const pageData = (
-      await axios.post(ROUTES_API.LOGIN, { email: email, password: password })
+      await axios.post(ROUTES_API.LOGIN, { email: email, password: password, locale })
     ).data.pageData;
     if (!pageData.is_success) {
       return { error: pageData.message };

--- a/app/[locale]/(auth)/sign-up/page.tsx
+++ b/app/[locale]/(auth)/sign-up/page.tsx
@@ -3,6 +3,7 @@ import ROUTES_API from "~/constants/urls/api.urls";
 import AuthCard from "~/app/components/cards/authentication.card";
 import { redirect } from "next/navigation";
 import { cookies } from "next/headers";
+import { getLocale } from "next-intl/server";
 import axios from "axios";
 
 export default function SignUpPage() {
@@ -12,12 +13,14 @@ export default function SignUpPage() {
     const username = formData.get("username") as string;
     const email = formData.get("email") as string;
     const password = formData.get("password") as string;
+    const locale = await getLocale();
 
     const pageData = (
       await axios.post(ROUTES_API.SIGN_UP, {
         email: email,
         password: password,
         username: username,
+        locale,
       })
     ).data.pageData;
 

--- a/app/api/backend/auth/login/route.ts
+++ b/app/api/backend/auth/login/route.ts
@@ -6,8 +6,9 @@ export async function POST(req: NextRequest) {
 
   const email = body?.email;
   const password = body?.password;
+  const locale = body?.locale || "en";
 
-  const data = await authController.logIn(email, password);
+  const data = await authController.logIn(email, password, locale);
 
   return NextResponse.json(data);
 }

--- a/app/api/backend/auth/sign-up/route.ts
+++ b/app/api/backend/auth/sign-up/route.ts
@@ -7,8 +7,9 @@ export async function POST(req: NextRequest) {
   const username = body?.username;
   const email = body?.email;
   const password = body?.password;
+  const locale = body?.locale || "en";
 
-  const data = await authController.signUp(email, password, username);
+  const data = await authController.signUp(email, password, username, locale);
 
   return NextResponse.json(data);
 }

--- a/hash-password.ts
+++ b/hash-password.ts
@@ -1,0 +1,8 @@
+// hash-password.ts
+import { hash } from "bcryptjs";
+
+(async () => {
+  const password = "123"; // Cambia esto si quieres
+  const hashed = await hash(password, 10);
+  console.log("Hashed password:", hashed);
+})();

--- a/src/application/use-cases/auth.use-case.ts
+++ b/src/application/use-cases/auth.use-case.ts
@@ -8,13 +8,14 @@ export class AuthUseCases {
   async signUp(
     email: string,
     password: string,
-    name: string
+    name: string,
+    locale: string
   ): Promise<{
     token: string | null;
     message: string;
     is_success: boolean;
   }> {
-    const t = await getTranslations("AuthPage");
+    const t = await getTranslations({ locale, namespace: "AuthPage" });
     const repository =
       repositoryContainer.get<IUserRepository>("IUserRepository");
 
@@ -59,13 +60,14 @@ export class AuthUseCases {
 
   async logIn(
     email: string,
-    password: string
+    password: string,
+    locale: string
   ): Promise<{
     token: string | null;
     message: string;
     is_success: boolean;
   }> {
-    const t = await getTranslations("AuthPage");
+    const t = await getTranslations({ locale, namespace: "AuthPage" });
     const repository =
       repositoryContainer.get<IUserRepository>("IUserRepository");
 

--- a/src/interface-adapters/controllers/auth.controller.ts
+++ b/src/interface-adapters/controllers/auth.controller.ts
@@ -4,23 +4,20 @@ export class AuthController {
   async signUp(
     email: string,
     password: string,
-    name: string
-  ): Promise<{
-    pageData: object;
-  }> {
-    const pageData = await authUseCases.signUp(email, password, name);
+    name: string,
+    locale: string
+  ): Promise<{ pageData: object }> {
+    const pageData = await authUseCases.signUp(email, password, name, locale);
     return { pageData };
   }
 
   async logIn(
     email: string,
-    password: string
-  ): Promise<{
-    pageData: object;
-  }> {
-    const pageData = await authUseCases.logIn(email, password);
+    password: string,
+    locale: string
+  ): Promise<{ pageData: object }> {
+    const pageData = await authUseCases.logIn(email, password, locale);
     return { pageData };
   }
 }
-
 export const authController = new AuthController();


### PR DESCRIPTION
This fix ensures that the selected locale is properly passed from the frontend to the backend during login and signup. Error messages are now translated based on the user's language preference using next-intl.